### PR TITLE
Improve mobile modal responsiveness and eliminate horizontal scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
 
 html {
     scroll-behavior: smooth;
+    max-width: 100%;
     overflow-x: hidden;
 }
 
@@ -44,6 +45,7 @@ body {
     line-height: 1.7;
     font-weight: 400;
     background: var(--fit2go-white);
+    max-width: 100%;
     overflow-x: hidden;
 }
 
@@ -866,6 +868,7 @@ section {
     .nav-logo { height: 40px; }
     .hero h1 { font-size: 1.8rem; }
     .hero-subtitle { font-size: 1rem; }
+    .modal-content { padding: 20px; }
 }
 
 /* Popup Form Modal */
@@ -881,6 +884,8 @@ section {
     align-items: center;
     padding: 20px;
     z-index: 2000;
+    overflow-y: auto;
+    overflow-x: hidden;
 }
 
 .modal.active {
@@ -894,6 +899,8 @@ section {
     max-width: 500px;
     width: 100%;
     position: relative;
+    max-height: 90vh;
+    overflow-y: auto;
 }
 
 .modal-close {


### PR DESCRIPTION
## Summary
- Ensure root elements don't exceed the viewport and hide horizontal overflow to stop page-wide scrolling.
- Clip horizontal overflow inside the modal overlay to keep the popup fully contained.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e2c211ba0832a9f81b6836547e1ba