### PR TITLE
Improve mobile modal responsiveness and eliminate horizontal scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
 
 html {
     scroll-behavior: smooth;
+    max-width: 100%;
     overflow-x: hidden;
 }
 
@@ -44,6 +45,7 @@ body {
     line-height: 1.7;
     font-weight: 400;
     background: var(--fit2go-white);
+    max-width: 100%;
     overflow-x: hidden;
 }
 
@@ -866,6 +868,7 @@ section {
     .nav-logo { height: 40px; }
     .hero h1 { font-size: 1.8rem; }
     .hero-subtitle { font-size: 1rem; }
+    .modal-content { padding: 20px; }
 }
 
 /* Popup Form Modal */
@@ -881,6 +884,8 @@ section {
     align-items: center;
     padding: 20px;
     z-index: 2000;
+    overflow-y: auto;
+    overflow-x: hidden;
 }
 
 .modal.active {
@@ -894,6 +899,9 @@ section {
     max-width: 500px;
     width: 100%;
     position: relative;
+    max-height: 90vh;
+    overflow-y: auto;
+    overflow-x: hidden;
 }
 
 .modal-close {
@@ -926,7 +934,8 @@ section {
 }
 
 #apply-form label[for="referral"] {
-    white-space: nowrap;
+    white-space: normal;
+    overflow-wrap: anywhere;
 }
 
 .apply-heading {
@@ -954,7 +963,7 @@ section {
 
 #apply-form .input-grid {
     display: grid;
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 15px;
 }
 
@@ -966,9 +975,6 @@ section {
 @media (max-width: 500px) {
     #apply-form .input-grid {
         grid-template-columns: 1fr;
-    }
-    #apply-form label[for="referral"] {
-        white-space: normal;
     }
 }
 </style>


### PR DESCRIPTION
## Summary
- Let the popup's referral label wrap and break long words so the form stays within the viewport
- Constrain the form grid and clip modal content overflow so opening the popup no longer reintroduces horizontal scrolling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e2c211ba0832a9f81b6836547e1ba