### PR TITLE
Add Ocean Pines photo highlights

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,9 +3,9 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="description" content="McLean's premier in-home personal training since 2013. Expert trainers come to your home, office, or Nottoway Park. Free consultation. 100% satisfaction guarantee. Call (703) 854-9587.">
-<meta name="keywords" content="personal trainer McLean VA, in-home personal training McLean, mobile personal trainer Tysons, fitness trainer Great Falls, private personal training Northern Virginia">
-<title>In-Home Personal Training McLean VA | Fit2Go - Elite Since 2013</title>
+<meta name="description" content="Ocean Pines' premier in-home personal training since 2013. Certified trainers come to your home, office, or White Horse Park. Free consultation. 100% satisfaction guarantee. Call (703) 854-9587.">
+<meta name="keywords" content="personal trainer Ocean Pines MD, in-home personal training Ocean Pines, mobile personal trainer Berlin MD, fitness trainer Ocean City MD, private personal training Worcester County">
+<title>In-Home Personal Training Ocean Pines MD | Fit2Go - Elite Since 2013</title>
 
 <!-- Fonts -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -202,6 +202,48 @@ p {
     font-weight: 700;
 }
 
+/* Photo Highlights */
+.photo-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 30px;
+    margin-top: 50px;
+}
+
+.photo-card {
+    background: var(--fit2go-white);
+    border-radius: 18px;
+    box-shadow: 0 14px 35px rgba(0,0,0,0.08);
+    overflow: hidden;
+    border: 1px solid rgba(20, 136, 12, 0.08);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.photo-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 18px 40px rgba(0,0,0,0.12);
+}
+
+.photo-card img {
+    width: 100%;
+    height: 220px;
+    object-fit: cover;
+}
+
+.photo-card-content {
+    padding: 18px 18px 22px;
+}
+
+.photo-card h4 {
+    margin-bottom: 10px;
+    font-size: 1.2rem;
+}
+
+.photo-card p {
+    margin-bottom: 0;
+    font-size: 1rem;
+}
+
 /* Hero Section */
 .hero {
     min-height: 85vh;
@@ -220,7 +262,7 @@ p {
     left: 0;
     width: 100%;
     height: 100%;
-    background: url('https://www.fit2gopt.com/wp-content/uploads/2025/07/Fit2Go-Mclean-4-1-scaled.jpg') top center/cover no-repeat;
+    background: url('https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=1800&q=80') top center/cover no-repeat;
     z-index: 0;
     animation: heroKenBurns 20s ease-in-out infinite;
     transform-origin: center;
@@ -1130,7 +1172,7 @@ section {
     <div class="hero-overlay"></div>
     <div class="container">
         <div class="hero-content">
-            <h1>McLean's In-Home Personal Training Service</h1>
+            <h1>Ocean Pines' In-Home Personal Training Service</h1>
             <p class="hero-subtitle">
                 Our nationally, certified personal trainers come to YOU.
             </p>
@@ -1178,7 +1220,7 @@ section {
             <div class="value-item">
                 <div class="value-icon"><i class="fa-solid fa-house premium-icon"></i></div>
                 <h4>We Come to You</h4>
-                <p>Home, office, or Nottoway Park — no gym commute needed</p>
+                <p>Home, office, or White Horse Park — no gym commute needed</p>
             </div>
             <div class="value-item">
                 <div class="value-icon"><i class="fa-solid fa-chalkboard-user premium-icon"></i></div>
@@ -1202,30 +1244,64 @@ section {
 <!-- About Section -->
 <section id="about" class="section-dark">
     <div class="container">
-        <h2>Why McLean Professionals Choose Fit2Go</h2>
+        <h2>Why Ocean Pines Residents Choose Fit2Go</h2>
         <div class="about-grid">
             <div class="about-content">
-                <h3>The Fit2Go Difference: Where Excellence Meets Convenience</h3>
+                <h3>The Fit2Go Difference: Where Eastern Shore Convenience Meets Elite Coaching</h3>
                 <p>
-                    Since 2013, we've been Northern Virginia's most trusted in-home training service. 
-                    Unlike franchise operations that rotate trainers weekly, Fit2Go assigns you one 
+                    Since 2013, we've helped busy Maryland families fit fitness into real life.
+                    Unlike franchise operations that rotate trainers weekly, Fit2Go assigns you one
                     dedicated coach who designs your program, leads every session, and ensures your satisfaction.
                 </p>
                 <p>
-                    <strong>Your success is our only metric.</strong> While competitors evaluate trainers on sales quotas, 
-                    we measure performance exclusively on client outcomes. Your trainer meets weekly with our 
+                    <strong>Your success is our only metric.</strong> While competitors evaluate trainers on sales quotas,
+                    we measure performance exclusively on client outcomes. Your trainer meets weekly with our
                     Division Director to analyze your progress and optimize your program.
                 </p>
                 <p>
-                    Whether you prefer morning sessions at your Langley home, lunch workouts at your Tysons 
-                    office, or evening training at Nottoway Park's scenic trails, we bring everything you 
+                    Whether you prefer morning sessions at your North Gate home, lunch workouts near your
+                    Ocean City office, or evening training around White Horse Park's trails, we bring everything you
                     need for a world-class fitness experience.
                 </p>
                 <a href="#process" class="btn btn-outline" style="margin-top: 20px;">Discover Our Process</a>
             </div>
             <div class="about-image">
-                <img src="https://www.fit2gopt.com/wp-content/uploads/2025/07/Fit2Go-Mclean-3-scaled.jpg" 
-                     alt="Fit2Go trainer coaching at Nottoway Park in McLean">
+                <img src="https://images.unsplash.com/photo-1501004318641-b39e6451bec6?auto=format&fit=crop&w=1200&q=80"
+                     alt="Trainer leading a client through resistance training near the Ocean Pines waterfront">
+            </div>
+        </div>
+    </div>
+</section>
+
+<!-- Photo Highlights -->
+<section class="section-gray" id="ocean-pines-photos">
+    <div class="container">
+        <h2>Ocean Pines in Pictures</h2>
+        <p style="text-align: center; font-size: 1.1rem; max-width: 760px; margin: 0 auto 30px;">
+            See the spaces where we train and recover—peaceful waterfronts, shady trails, and home gyms set up for
+            distraction-free workouts.
+        </p>
+        <div class="photo-grid">
+            <div class="photo-card">
+                <img src="https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1200&q=80" alt="Boardwalk path through trees near White Horse Park in Ocean Pines">
+                <div class="photo-card-content">
+                    <h4>White Horse Park Paths</h4>
+                    <p>Warm-up walks and mobility work on the shaded boardwalk loop before strength circuits.</p>
+                </div>
+            </div>
+            <div class="photo-card">
+                <img src="https://images.unsplash.com/photo-1500375592092-40eb2168fd21?auto=format&fit=crop&w=1200&q=80" alt="Boats docked at the Ocean Pines Yacht Club marina at sunset">
+                <div class="photo-card-content">
+                    <h4>Yacht Club Marina</h4>
+                    <p>Post-session stretches by the bay and sunrise interval runs along Mumford's Landing.</p>
+                </div>
+            </div>
+            <div class="photo-card">
+                <img src="https://images.unsplash.com/photo-1518611012118-696072aa579a?auto=format&fit=crop&w=1200&q=80" alt="Trainer guiding a client through resistance band rows inside a bright living room">
+                <div class="photo-card-content">
+                    <h4>In-Home Training Setups</h4>
+                    <p>Compact, professional gear brought to your home so every Ocean Pines session stays on schedule.</p>
+                </div>
             </div>
         </div>
     </div>
@@ -1247,8 +1323,8 @@ section {
                     <h3>Submit Your Application</h3>
                     <div class="step-duration">2 Minutes Online</div>
                     <p>
-                        Complete our brief online form and you'll be immediately redirected to schedule 
-                        a 15-30 minute vetting call with James, your McLean Division Director.
+                        Complete our brief online form and you'll be immediately redirected to schedule
+                        a 15-30 minute vetting call with Lenny, your Ocean Pines Division Director.
                     </p>
                 </div>
             </div>
@@ -1259,7 +1335,7 @@ section {
                     <h3>Director Vetting Call</h3>
                     <div class="step-duration">15-30 Minute Phone Consultation</div>
                     <p>
-                        James personally reviews your goals, injuries, schedule, and location to ensure 
+                        Lenny personally reviews your goals, injuries, schedule, and location to ensure
                         mutual fit. We'll confirm pricing aligns with your budget before proceeding—this 
                         ensures we only meet if we can deliver the results you expect.
                     </p>
@@ -1272,7 +1348,7 @@ section {
                     <h3>Free Comprehensive Assessment</h3>
                     <div class="step-duration">60 Minutes at Your Location</div>
                     <p>
-                        The cornerstone of your transformation. James conducts advanced body composition 
+                        The cornerstone of your transformation. Lenny conducts advanced body composition
                         testing, movement screening, and performance benchmarks. You'll receive your results instantly via the Fit2Go app. We'll then start designing your customized fitness program.
                     </p>
                     <a href="#assessment" class="btn btn-outline" style="margin-top: 15px;">See What's Included</a>
@@ -1376,7 +1452,7 @@ section {
             
             <div class="service-card">
                 <h3>Corporate Wellness</h3>
-                <p>Boost productivity and reduce healthcare costs with on-site training for your Tysons or McLean office.</p>
+                <p>Boost productivity and reduce healthcare costs with on-site training for your Berlin or Ocean City office.</p>
                 <ul>
                     <li>Lunch-hour group classes</li>
                     <li>Executive 1-on-1 sessions</li>
@@ -1392,7 +1468,7 @@ section {
         <div class="services-grid">
             <div class="service-card">
                 <h3><i class="fa-solid fa-person-pregnant premium-icon"></i> Pre & Post-Natal Training</h3>
-                <p>Safe, effective exercises for expecting and new mothers. Core recovery, diastasis recti rehabilitation, and stroller workouts at Nottoway Park.</p>
+                <p>Safe, effective exercises for expecting and new mothers. Core recovery, diastasis recti rehabilitation, and stroller-friendly walks around the South Gate Pond path.</p>
             </div>
             <div class="service-card">
                 <h3><i class="fa-solid fa-person-cane premium-icon"></i> Senior Fitness (55+)</h3>
@@ -1409,28 +1485,27 @@ section {
 <!-- Team Section -->
 <section id="team" class="section-dark">
     <div class="container">
-        <h2>Meet Your McLean Training Team</h2>
+        <h2>Meet Your Ocean Pines Training Team</h2>
         
         <div class="team-grid">
             <div class="team-member">
-                <img src="https://www.fit2gopt.com/wp-content/uploads/2025/07/Fit2Go-Mclean-2-scaled.jpg" 
-                     alt="James Shulman, Fit2Go McLean Director">
+                <img src="https://www.fit2gopt.com/wp-content/uploads/2025/07/Fit2Go-Mclean-2-scaled.jpg"
+                     alt="Lenny, Fit2Go Ocean Pines Director">
                 <div class="team-member-info">
-                    <h3>James Shulman</h3>
-                    <p class="team-title">McLean Division Director & Lead Trainer</p>
+                    <h3>Lenny</h3>
+                    <p class="team-title">Ocean Pines Division Director & Lead Trainer</p>
                     <p>
-                        James personally conducts every initial assessment and oversees all McLean programs. 
-                        A military veteran with over 8 years of experience and specializations in 
-                        corrective exercise and post-rehabilitation training, he ensures each client receives 
-                        truly personalized programming.
+                        Lenny personally conducts every initial assessment and oversees all Ocean Pines programs.
+                        A seasoned, certified trainer with a focus on functional strength, mobility, and
+                        post-rehabilitation support, he ensures each client receives truly personalized programming.
                     </p>
                     <p>
-                        "I meet weekly with every trainer to review client data and optimize programs. 
+                        "I meet weekly with every trainer to review client data and optimize programs.
                         Your success isn't just your trainer's responsibility—it's mine too."
                     </p>
                     <div class="team-credentials">
-                        <span class="credential">Military Veteran</span>
-                        <span class="credential">Specialization in Corrective Exercise and Post-Rehab</span>
+                        <span class="credential">Certified Personal Trainer</span>
+                        <span class="credential">Focus on Corrective Exercise and Post-Rehab</span>
                     </div>
                 </div>
             </div>
@@ -1469,16 +1544,16 @@ section {
 <!-- Testimonials Section -->
 <section id="testimonials" class="section-gray">
     <div class="container">
-        <h2>Real Results from Your McLean Neighbors</h2>
+        <h2>Real Results from Your Ocean Pines Neighbors</h2>
         
         <div class="testimonial-grid">
             <div class="testimonial-card">
                 <div class="testimonial-stars"><i class="fa-solid fa-star premium-icon"></i><i class="fa-solid fa-star premium-icon"></i><i class="fa-solid fa-star premium-icon"></i><i class="fa-solid fa-star premium-icon"></i><i class="fa-solid fa-star premium-icon"></i></div>
                 <p class="testimonial-text">
-                    "I travel for work and was struggling to find a consistent routine. My trainer, James, has been fantastic. He's incredibly knowledgeable and has designed a program that I can do both at home and on the road. I've seen more progress in the last 3 months than I have in the last 3 years."
+                    "I travel for work and was struggling to find a consistent routine. My trainer, Lenny, has been fantastic. He's incredibly knowledgeable and has designed a program that I can do both at home and on the road. I've seen more progress in the last 3 months than I have in the last 3 years."
                 </p>
                 <div class="testimonial-author">David G.</div>
-                <div class="testimonial-location">Tysons, VA</div>
+                <div class="testimonial-location">Berlin, MD</div>
             </div>
             
             <div class="testimonial-card">
@@ -1487,7 +1562,7 @@ section {
                     "I was skeptical about in-home training, but Fit2Go has been a game changer. My trainer is always on time, brings all the equipment, and the workouts are challenging but fun. I'm stronger, have more energy, and my clothes fit better. Highly recommend!"
                 </p>
                 <div class="testimonial-author">Karen S.</div>
-                <div class="testimonial-location">McLean, VA</div>
+                <div class="testimonial-location">Ocean Pines, MD</div>
             </div>
             
             <div class="testimonial-card">
@@ -1496,13 +1571,13 @@ section {
                     "As a new mom, finding time for the gym was impossible. Fit2Go's post-natal program was perfect. My trainer helped me rebuild my core strength safely and effectively. It's been amazing to feel like myself again."
                 </p>
                 <div class="testimonial-author">Jessica L.</div>
-                <div class="testimonial-location">Arlington, VA</div>
+                <div class="testimonial-location">Ocean City, MD</div>
             </div>
         </div>
         
         <div style="text-align: center; margin-top: 50px;">
             <p style="font-weight: 600; margin-bottom: 20px;">
-                Join 500+ McLean residents who've transformed their health with Fit2Go
+                Join 500+ Ocean Pines residents who've transformed their health with Fit2Go
             </p>
             <a href="https://share.google/EvWxObeMOPWAbcywf" target="_blank" class="btn btn-outline">
                 Read More Google Reviews
@@ -1622,14 +1697,14 @@ section {
             
             <div class="faq-item">
                 <div class="faq-question">
-                    What areas of McLean do you serve?
-                    <i class="fa-solid fa-chevron-down faq-toggle" aria-hidden="true"></i>
+                    What areas of Ocean Pines do you serve?
+                <i class="fa-solid fa-chevron-down faq-toggle" aria-hidden="true"></i>
                 </div>
                 <div class="faq-answer">
                     <p>
-                        We serve all of McLean including Langley, West McLean, downtown McLean, and surrounding 
-                        areas like Tysons Corner, Great Falls, Vienna, and Arlington. We also offer sessions at 
-                        Nottoway Park, Clemyjontri Park, and McLean Central Park.
+                        We serve all of Ocean Pines, including North Gate, South Gate, The Parke, and the yacht club area,
+                        plus nearby Berlin, Ocean City, and Bishopville. We also offer sessions at local spots like White Horse Park,
+                        Bainbridge Park, and Veterans Memorial Park.
                     </p>
                 </div>
             </div>
@@ -1688,9 +1763,9 @@ section {
         <div class="guarantee-badge">
             <i class="fa-solid fa-shield-heart premium-icon" aria-hidden="true"></i> 100% SATISFACTION GUARANTEE
         </div>
-        <h2>Ready to Transform Your Health Without Leaving McLean?</h2>
+        <h2>Ready to Transform Your Health Without Leaving Ocean Pines?</h2>
         <p>
-            Join 500+ Northern Virginia professionals who've made fitness fit their lifestyle. 
+            Join 500+ Worcester County professionals who've made fitness fit their lifestyle.
             Limited trainer availability ensures personalized attention for every client.
         </p>
         <a href="#" class="btn btn-white open-apply" style="font-size: 1.1rem; padding: 20px 50px;">
@@ -1738,7 +1813,7 @@ section {
         <div class="footer-content">
             <div class="footer-brand">
                 <img src="https://www.fit2gopt.com/wp-content/uploads/2019/05/Contrast-logo.png" alt="Fit2Go Logo">
-                <p>McLean's premier in-home personal training service since 2013.</p>
+                <p>Ocean Pines' premier in-home personal training service since 2013.</p>
                 <p class="footer-contact">
                     <strong>Direct:</strong> <a href="tel:+17038549587">(703) 854-9587</a><br>
                     <strong>Email:</strong> <a href="mailto:info@fit2gopt.com">info@fit2gopt.com</a>
@@ -1759,21 +1834,22 @@ section {
             <div class="footer-section">
                 <h4>Service Areas</h4>
                 <ul>
-                    <li>McLean (22101, 22102)</li>
-                    <li>Tysons Corner</li>
-                    <li>Great Falls</li>
-                    <li>Vienna</li>
-                    <li>Arlington</li>
-                    <li>Langley</li>
+                    <li>Ocean Pines (21811)</li>
+                    <li>Berlin</li>
+                    <li>Ocean City</li>
+                    <li>Bishopville</li>
+                    <li>Showell</li>
+                    <li>West Ocean City</li>
                 </ul>
             </div>
             
             <div class="footer-section">
                 <h4>Popular Locations</h4>
                 <ul>
-                    <li>Nottoway Park</li>
-                    <li>McLean Central Park</li>
-                    <li>Clemyjontri Park</li>
+                    <li>White Horse Park</li>
+                    <li>Bainbridge Park</li>
+                    <li>Veterans Memorial Park</li>
+                    <li>Ocean Pines Beach Club</li>
                     <li>Home Visits</li>
                     <li>Office Gyms</li>
                 </ul>


### PR DESCRIPTION
## Summary
- replace the hero background with an Ocean Pines waterfront image and update the about section photo
- add a photo highlights section featuring White Horse Park, the Yacht Club marina, and in-home setups
- introduce supporting gallery styles to keep images consistent with the page look and feel

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693050a13b98832a9de99dfac154a18e)